### PR TITLE
Fix Snackbar look like wrong size 🔨 

### DIFF
--- a/NotificationBanner/Classes/GrowingNotificationBanner.swift
+++ b/NotificationBanner/Classes/GrowingNotificationBanner.swift
@@ -188,6 +188,9 @@ open class GrowingNotificationBanner: BaseNotificationBanner {
     }
 
     override func spacerViewHeight() -> CGFloat {
+        if self.bannerPosition == .bottom {
+            return .zero
+        }
         return super.spacerViewHeight() + heightAdjustment
     }
 }


### PR DESCRIPTION
Sometimes 1 line of code can make the difference.
The problem was the spacer added was consuming more space and it was flaky.
I think we have to automatically test this case. Let's discuss this on our meeting.

## How to test:
Go to blueground and make it use this commit.
This line was reproducing the problem. Now it works fine.
```swift
DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
     self.showSnackbar(type: .positive, text: "Hello world this is a simple text that I wrote bymyself. I see you!")
}
```

https://user-images.githubusercontent.com/14034942/226489540-a718adb7-ea80-47e9-a1e2-b07051d5ec5d.mp4
